### PR TITLE
Create .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+group: travis_latest
+language: python
+cache: pip
+python:
+  - 2.7
+  - 3.6
+matrix:
+  allow_failures:
+    - python: 3.6
+  include:
+    - python: 2.7
+    #- python: 3.4
+    #- python: 3.5
+    - python: 3.6
+    #- python: 3.7
+    #  dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+    #  sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+install:
+  - pip install -r byob/requirements.txt
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+  - true  # add other tests here
+notifications:
+  on_success: change
+  on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Fixes #3 Travis CI would need to be turned ON for this repo by @malwaredllc going to https://travis-ci.com/profile and logging in with GitHub credentials.

Travis CI will run [flake8](http://flake8.pycqa.org) tests on Python 2.7 and 3.7 to find Python syntax errors and undefined names.  Python 3 will be run in __allow_failures__ mode because it is not yet a supported platform.  #32

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree