### PR TITLE
Travis CI: Remove allow_failures on Python 3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ group: travis_latest
 language: python
 cache: pip
 matrix:
-  allow_failures:
-    - python: 3.6
   include:
     - python: 2.7
     #- python: 3.4

--- a/byob/core/database.py
+++ b/byob/core/database.py
@@ -14,6 +14,11 @@ import collections
 # modules
 import util
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 class Database(sqlite3.Connection):
     """ 
     Builds and manages a persistent Sqlite3 database for the


### PR DESCRIPTION
Now that #40 has landed we can disable __allow_failures__.