### PR TITLE
Replace md5 library with hashlib

### DIFF
--- a/byob/core/database.py
+++ b/byob/core/database.py
@@ -4,9 +4,9 @@
 
 # standard library
 import os
-import md5
 import json
 import sqlite3
+import hashlib
 import datetime
 import collections
 
@@ -230,7 +230,7 @@ COMMIT;
         if isinstance(info, dict):
 
             if not info.get('uid'):
-                info['uid'] = md5.new(info['public_ip'] + info['mac_address']).hexdigest()
+                info['uid'] = hashlib.md5(info['public_ip'] + info['mac_address']).hexdigest()
                 info['joined'] = datetime.datetime.now()
 
             info['online'] = 1
@@ -275,7 +275,7 @@ COMMIT;
         """
         if isinstance(task, dict):
             if 'uid' not in task:
-                task['uid'] = md5.new(task['session'] + task['task'] + datetime.datetime.now().ctime()).hexdigest()
+                task['uid'] = hashlib.md5(task['session'] + task['task'] + datetime.datetime.now().ctime()).hexdigest()
                 task['issued'] = datetime.datetime.now()
                 self.execute_query('insert into tbl_tasks (uid, session, task, issued) values (:uid, :session, :task, :issued)', params={"uid": task['uid'],  "session": task['session'], "task": task['task'], "issued": task['issued']}, returns=False)
                 task['issued'] = task['issued'].ctime()

--- a/byob/modules/ransom.py
+++ b/byob/modules/ransom.py
@@ -5,10 +5,10 @@
 # standard library
 import os
 import sys
-import md5
 import time
 import Queue
 import base64
+import hashlib
 import StringIO
 
 # packages
@@ -26,7 +26,7 @@ packages = ['_winreg','Cryptodome.PublicKey.RSA','Cryptodome.Cipher.PKCS1_OAEP']
 platforms = ['win32']
 threads = {}
 tasks = Queue.Queue()
-registry_key = md5.new(util.mac_address()).hexdigest()
+registry_key = hashlib.md5(util.mac_address()).hexdigest()
 filetypes = ['.pdf','.zip','.ppt','.doc','.docx','.rtf','.jpg','.jpeg','.png','.img','.gif','.mp3','.mp4','.mpeg',
 	     '.mov','.avi','.wmv','.rtf','.txt','.html','.php','.js','.css','.odt', '.ods', '.odp', '.odm', '.odc',
              '.odb', '.doc', '.docx', '.docm', '.wps', '.xls', '.xlsx', '.xlsm', '.xlsb', '.xlk', '.ppt', '.pptx',


### PR DESCRIPTION
The `md5` library is deprecated in Python 2 and does not exist in Python 3.

The [Python 2 docs](https://docs.python.org/2/library/md5.html) says:
> Deprecated since version 2.5: Use the `hashlib` module instead.

If we try to import the module we get errors:
```
$ python2 -W error
Python 2.7.15 (default, Jun 27 2018, 13:05:28) 
[GCC 8.1.1 20180531] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import md5
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/md5.py", line 8, in <module>
    DeprecationWarning, 2)
DeprecationWarning: the md5 module is deprecated; use hashlib instead
```

```
$ python3 -W error
Python 3.7.0 (default, Sep 15 2018, 19:13:07) 
[GCC 8.2.1 20180831] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import md5
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'md5'
```
