### PR TITLE
Replace deprecated version parameter with add_argument

### DIFF
--- a/byob/client.py
+++ b/byob/client.py
@@ -173,7 +173,7 @@ def main():
     parser.add_argument(
         '-v', '--version',
         action='version',
-        version='0.1.5',
+        version='0.2',
     )
 
     options = parser.parse_args()

--- a/byob/client.py
+++ b/byob/client.py
@@ -121,9 +121,10 @@ def main():
     """
     util.display(globals()['__banner'], color=random.choice(filter(lambda x: bool(str.isupper(x) and 'BLACK' not in x), dir(colorama.Fore))), style='normal')
 
-    parser = argparse.ArgumentParser(prog='client.py',
-                                    version='0.1.5',
-                                    description="Generator (Build Your Own Botnet)")
+    parser = argparse.ArgumentParser(
+        prog='client.py',
+        description="Generator (Build Your Own Botnet)"
+    )
 
     parser.add_argument('host',
                         action='store',
@@ -168,6 +169,12 @@ def main():
                         action='store_true',
                         help='compile client into a standalone executable for the current host platform',
                         default=False)
+
+    parser.add_argument(
+        '-v', '--version',
+        action='version',
+        version='0.1.5',
+    )
 
     options = parser.parse_args()
     key = base64.b64encode(os.urandom(16))

--- a/byob/server.py
+++ b/byob/server.py
@@ -114,7 +114,7 @@ def main():
     parser.add_argument(
         '-v', '--version',
         action='version',
-        version='0.1.5',
+        version='0.2',
     )
 
     modules = os.path.abspath('modules')

--- a/byob/server.py
+++ b/byob/server.py
@@ -62,9 +62,9 @@ __banner__ = """
 def main():
 
     parser = argparse.ArgumentParser(
-        prog='server.py',
-        version='0.1.5',
-        description="Command & Control Server (Build Your Own Botnet)")
+        prog='client.py',
+        description="Generator (Build Your Own Botnet)"
+    )
 
     parser.add_argument(
         '--host',
@@ -109,6 +109,12 @@ def main():
         '--debug',
         action='store_true',
         help='Additional logging'
+    )
+
+    parser.add_argument(
+        '-v', '--version',
+        action='version',
+        version='0.1.5',
     )
 
     modules = os.path.abspath('modules')


### PR DESCRIPTION
The `version` parameter in `ArgumentParser` is deprecated.

```
$ python2 -W error byob/client.py -v
...
Traceback (most recent call last):
  File "byob/client.py", line 428, in <module>
    main()
  File "byob/client.py", line 126, in main
    description="Generator (Build Your Own Botnet)")
  File "/usr/lib/python2.7/argparse.py", line 1576, in __init__
    """instead""", DeprecationWarning)
DeprecationWarning: The "version" argument to ArgumentParser is deprecated. Please use "add_argument(..., action='version', version="N", ...)" instead
```
