### PR TITLE
Travis CI: Add more flake8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,16 @@
 group: travis_latest
 language: python
 cache: pip
-matrix:
-  include:
-    - python: 2.7
-    #- python: 3.4
-    #- python: 3.5
-    #- python: 3.6
-    - python: 3.7
-      dist: xenial    # required for Python >= 3.7 (travis-ci/travis-ci#9069)
-      sudo: required  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+python:
+  - 2.7
+  # - 3.6
+  # - 3.7
+  - 3.8
 install:
   - pip install flake8 -r byob/requirements.txt
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 group: travis_latest
+os: linux
+dist: focal
 language: python
 cache: pip
 python:

--- a/byob/core/payloads.py
+++ b/byob/core/payloads.py
@@ -525,7 +525,7 @@ class Payload():
             if 'jobs' in attribute:
                 return json.dumps({a: status(_threads[a].name) for a in self.handlers if self.handlers[a].is_alive()})
             elif 'privileges' in attribute:
-                return json.dumps({'username': self.info.get('username'),  'administrator': 'true' if bool(os.getuid() == 0 if os.name is 'posix' else ctypes.windll.shell32.IsUserAnAdmin()) else 'false'})
+                return json.dumps({'username': self.info.get('username'),  'administrator': 'true' if bool(os.getuid() == 0 if os.name == 'posix' else ctypes.windll.shell32.IsUserAnAdmin()) else 'false'})
             elif 'info' in attribute:
                 return json.dumps(self.info)
             elif hasattr(self, attribute):
@@ -556,7 +556,7 @@ class Payload():
         """
         globals()['_abort'] = True
         try:
-            if os.name is 'nt':
+            if os.name == 'nt':
                 clear_system_logs()
             if 'persistence' in globals():
                 global persistence

--- a/web-gui/buildyourownbotnet/core/payloads.py
+++ b/web-gui/buildyourownbotnet/core/payloads.py
@@ -528,7 +528,7 @@ class Payload():
             if 'jobs' in attribute:
                 return json.dumps({a: status(_threads[a].name) for a in self.handlers if self.handlers[a].is_alive()})
             elif 'privileges' in attribute:
-                return json.dumps({'username': self.info.get('username'),  'administrator': 'true' if bool(os.getuid() == 0 if os.name is 'posix' else ctypes.windll.shell32.IsUserAnAdmin()) else 'false'})
+                return json.dumps({'username': self.info.get('username'),  'administrator': 'true' if bool(os.getuid() == 0 if os.name == 'posix' else ctypes.windll.shell32.IsUserAnAdmin()) else 'false'})
             elif 'info' in attribute:
                 return json.dumps(self.info)
             elif hasattr(self, attribute):
@@ -559,7 +559,7 @@ class Payload():
         """
         globals()['_abort'] = True
         try:
-            if os.name is 'nt':
+            if os.name == 'nt':
                 clear_system_logs()
             if 'persistence' in globals():
                 global persistence


### PR DESCRIPTION
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.