### PR TITLE
BUG! + FIX request. In linux amdx64 docker image, python is not in path.

### DIFF
--- a/web-gui/docker-pyinstaller/Dockerfile-py3-amd64
+++ b/web-gui/docker-pyinstaller/Dockerfile-py3-amd64
@@ -47,6 +47,7 @@ RUN \
     && echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
     && source ~/.bashrc \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && echo 'eval "$(pyenv init --path)"' >> ~/.bashrc \
     && echo 'eval "$(pyenv init -)"' >> ~/.bashrc \
     && source ~/.bashrc \
     # install python


### PR DESCRIPTION
### Please use the Discord Support Server if you need help and reserve creating issues for bug reports.

**Describe the bug**
WARNING: `pyenv init -` no longer sets PATH.
Run `pyenv init` to see the necessary changes to make to your configuration.

This is the error generated when building a linux amd64 docker image.
This error means python is not in path.

in the file Dockerfile-py3-amd64:
line 55: && pip install --upgrade pip \
This is the line when error starts to occur. Since python is not in the path, so does pip thus this error happens during building the docker image:
"Bash: pip: command not found"
The image build will be unsuccessful.

**To Reproduce**
Steps to reproduce the behavior:
cd ~/Downloads/byob/web-gui/docker-pyinstaller
docker build -f Dockerfile-py3-amd64 -t nix-amd64 .

**Desktop (please complete the following information):**
 - OS: kali
 - Python version 3

**Additional context**
I've proposed a fix to this bug, please have a look. This fix will add python into path.
The same bug is probably occurs in the x32 linux image build.
Reference: https://github.com/pyenv/pyenv/issues/1906