### PR TITLE
Update Dockerfile-py3-i386

### DIFF
--- a/web-gui/docker-pyinstaller/Dockerfile-py3-i386
+++ b/web-gui/docker-pyinstaller/Dockerfile-py3-i386
@@ -32,6 +32,9 @@ RUN \
         uuid-dev \
         #upx
         upx \
+        #Python
+        python3-pip \
+        python3-dev \
     # do we really need to build openSSL on Ubuntu 20.04? Why not install from apt?
     && mkdir openssl \
     && cd openssl \
@@ -52,7 +55,7 @@ RUN \
     # install python
     && PATH="$HOME/openssl:$PATH"  CPPFLAGS="-O2 -I$HOME/openssl/include" CFLAGS="-I$HOME/openssl/include/" LDFLAGS="-L$HOME/openssl/lib -Wl,-rpath,$HOME/openssl/lib" LD_LIBRARY_PATH=$HOME/openssl/lib:$LD_LIBRARY_PATH LD_RUN_PATH="$HOME/openssl/lib" CONFIGURE_OPTS="--with-openssl=$HOME/openssl" PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pip install --upgrade pip \
+    && pip3 install --upgrade pip \
     # install pyinstaller
     && pip install pyinstaller==$PYINSTALLER_VERSION \
     && mkdir /src/ \


### PR DESCRIPTION
Docker Image is not building without these. 
Host OS is Ubuntu 20.04 (fresh install) as advised.